### PR TITLE
Use normalized click coordinates to fix click-to-delta overlay across resizes/panels

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -294,17 +294,6 @@ class Command:
 
       rx = (mx - x0) / float(tw)
       ry = (my - y0) / float(th)
-
-      # Scale to tdetector/native frame size, not the preview size
-      try:
-        main_mod = sys.modules.get('main') or importlib.import_module('main')
-        with main_mod._latest_frame_lock:
-          src_w, src_h = getattr(main_mod, "_latest_src_wh", (fw, fh))
-          if not src_w or not src_h:
-            src_w, src_h = fw, fh  # fallback
-      except Exception as e:
-         src_w, src_h = fw, fh
-
       fx = int(round(rx * fw))
       fy = int(round(ry * fh))
       last_click_pg = (mx, my)
@@ -319,7 +308,7 @@ class Command:
             det.set_click_point(fx, fy)
       except Exception as e:
         logger.debug(f"Failed to deliver click to detector: {e}")
-      logger.info(f"Click: pygame=({mx},{my})  frame=({fx},{fy})  rect=({x0},{y0},{tw}x{th}) preview=({fw}x{fh}) src=({src_w}x{src_h})")
+      logger.info(f"Click: pygame=({mx},{my})  frame=({fx},{fy})  rect=({x0},{y0},{tw}x{th}) src=({fw}x{fh})")
 
     try:
       logger.info("Resetting estimators.")

--- a/src/command.py
+++ b/src/command.py
@@ -294,6 +294,17 @@ class Command:
 
       rx = (mx - x0) / float(tw)
       ry = (my - y0) / float(th)
+
+      # Scale to tdetector/native frame size, not the preview size
+      try:
+        main_mod = sys.modules.get('main') or importlib.import_module('main')
+        with main_mod._latest_frame_lock:
+          src_w, src_h = getattr(main_mod, "_latest_src_wh", (fw, fh))
+          if not src_w or not src_h:
+            src_w, src_h = fw, fh  # fallback
+      except Exception as e:
+         src_w, src_h = fw, fh
+
       fx = int(round(rx * fw))
       fy = int(round(ry * fh))
       last_click_pg = (mx, my)
@@ -308,7 +319,7 @@ class Command:
             det.set_click_point(fx, fy)
       except Exception as e:
         logger.debug(f"Failed to deliver click to detector: {e}")
-      logger.info(f"Click: pygame=({mx},{my})  frame=({fx},{fy})  rect=({x0},{y0},{tw}x{th}) src=({fw}x{fh})")
+      logger.info(f"Click: pygame=({mx},{my})  frame=({fx},{fy})  rect=({x0},{y0},{tw}x{th}) preview=({fw}x{fh}) src=({src_w}x{src_h})")
 
     try:
       logger.info("Resetting estimators.")

--- a/src/main.py
+++ b/src/main.py
@@ -44,6 +44,7 @@ RADIO_CHANNELS = {
 _latest_frame_lock = threading.Lock()
 _latest_frame_np = None
 _latest_ids = []
+_latest_src_wh = (0, 0) # (w, h) of the detector frame BEFORE the preview resize
 
 def run(connection_type, use_vision=False, use_control=False, swarm_uris=None):
   cflib.crtp.init_drivers(enable_debug_driver=False)
@@ -113,8 +114,9 @@ def run(connection_type, use_vision=False, use_control=False, swarm_uris=None):
             continue
           last_ok = time.time()
 
-          # preview resize to keep it light
+          # record the detector size then preview-resize to keep it light
           h, w = frame.shape[:2]
+          src_w, src_h = w, h
           scale = min(max_w / w, max_h / h, 1.0)
           if scale < 1.0:
             frame = cv2.resize(frame, (int(w*scale), int(h*scale)))
@@ -122,11 +124,13 @@ def run(connection_type, use_vision=False, use_control=False, swarm_uris=None):
           # Store latest frame (BGR -> RGB) for pygame
           global _latest_frame_np
           global _latest_ids
+          global _latest_src_wh
           rgb = cv2.cvtColor(frame, cv2.COLOR_BGR2RGB)
           with _latest_frame_lock:
             _latest_frame_np = np.ascontiguousarray(rgb)
             ids = results.get("ids")
             _latest_ids = [] if ids is None else [int(i) for i in ids.flatten()]
+            _latest_src_wh = (src_w, src_h)
 
       vision_thread = threading.Thread(target=_vision_loop, daemon=True)
       vision_thread.start()

--- a/src/vision.py
+++ b/src/vision.py
@@ -158,6 +158,10 @@ class DetectorRT:
     # click-to-delta feature
     self._click_pt = None
     self._click_lock = threading.Lock()
+
+    # normalize click (u, v) in [0,1] x [0,1]; if set, takes precedence
+    self._click_norm = None
+
     # env toggles: 1=enabled, 0=disabled
     self._delta_enabled = bool(int(os.getenv("CLICK_DELTA_ENABLED", "1")))
     self._metric_enabled = bool(int(os.getenv("CLICK_DELTA_METRIC", "1")))
@@ -290,10 +294,22 @@ class DetectorRT:
   def set_click_point(self, x: int, y: int):
     with self._click_lock:
       self._click_pt = (int(x), int(y))
+      self._click_norm = None  # pixel click overrides normalized for this session
 
   def clear_click(self):
     with self._click_lock:
       self._click_pt = None
+      self._click_norm = None
+
+  def set_click_point_normalized(self, u: float, v: float):
+    """
+    Store a normlized click coordinate (u,v) in [0,1], independent of frame size.
+    The actual pixel  is resolved at overlay time using the current frame wxh.
+    """
+    u = float(max(0.0, min(1.0, u)))
+    v = float(max(0.0, min(1.0, v)))
+    with self._click_lock:
+      self._click_norm = (u, v)
 
   def toggle_delta(self, enabled: Optional[bool] = None):
     if enabled is None:
@@ -342,10 +358,27 @@ class DetectorRT:
   def _overlay_click_delta(self, frame: np.ndarray, results: Dict[str, Any]):
     if not self._delta_enabled:
       return
+
+    # REsolve click: normalized will take precedence, else use pixel if present
     with self._click_lock:
-      click = None if self._click_pt is None else tuple(self._click_pt)
-    if click is None:
+      click_px = None
+      if self._click_norm is not None:
+        u, v = self._click_norm
+        h, w = frame.shape[:2]
+        x = int(round(u * (w - 1)))
+        y = int(round(v * (h - 1)))
+        click_px = (x, y)
+      elif self._click_pt is not None:
+        click_px = tuple(self._click_pt)
+      else:
+        click_px = None
+
+    if click_px is None:
       return
+
+    click = click_px
+    click_x, click_y = click
+
     corners = results.get("corners")
     ids = results.get("ids")
     rvecs = results.get("rvecs")
@@ -354,12 +387,11 @@ class DetectorRT:
     chosen = self._nearest_marker_to_point(corners, ids, click)
     if chosen is None:
       # No target; draw click but no delta
-      cv2.drawMarker(frame, click, (200, 200, 255), cv2.MARKER_CROSS, 12, 2)
-      cv2.putText(frame, "No marker", (click[0]+8, click[1]-8), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (200,200,255), 1, cv2.LINE_AA)
+      cv2.drawMarker(frame, (click_x, click_y), (200, 200, 255), cv2.MARKER_CROSS, 12, 2)
+      cv2.putText(frame, "No marker", (click_x+8, click_y-8), cv2.FONT_HERSHEY_SIMPLEX, 0.5, (200,200,255), 1, cv2.LINE_AA)
       return
 
     idx, mid, cx, cy = chosen
-    click_x, click_y = click
     dx_px = int(round(click_x - cx))
     dy_px = int(round(click_y - cy))
 


### PR DESCRIPTION
This PR closes #81. Send normalized (u,v) clicks from PyGame and convert them to pixel coordinates inside `DetectorRT` at overlay time. This guarantees alignment even when the preview is scaled, letterboxed, or the UI reserves space for the bottom instruction panel.

## Changes

* `vision.py`:
  * Add `set_click_point_normalized(u, v)` that stores normalized clicks.
  * In `_overlay_click_delta`, compute pixel clicks from normalized values on the current frame dimensions.
* `command.py`:
  * When the user clicks the preview, compute normalized `(rx, ry)` within the displayed image rect and call `detector.set_click_point_normalized(rx, ry)` if available; gracefully fall back to pixel mode for older detectors.