### PR TITLE
Add pixel + metric distance to click-delta overlay and logs

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "intelligent-drone-swarm"
-version = "3.1.0"
+version = "3.2.0"
 requires-python = ">=3.10"
 dependencies = [
   "cflib",


### PR DESCRIPTION
This PR closes #102.

Augment the vision overlay to show:

1. **Pixel distance** between the clicked point and the nearest ArUco marker’s centroid (screen-space, in px).
2. **Metric norm** ‖dM‖ in meters when pose is available (the Euclidean distance from the marker center to the clicked ray–plane intersection).

Also include both values in the `click_delta` log event.