### PR TITLE
Swarm Formation Presets (stubs + keybindings)

### DIFF
--- a/src/command.py
+++ b/src/command.py
@@ -911,8 +911,28 @@ class Command:
           if event.type == pygame.KEYDOWN:
             if event.key == pygame.K_BACKSPACE:
               done = True
+
             if event.key == pygame.K_h:
               self._hover()
+
+            if event.key == pygame.K_1 and self.swarm:
+              try:
+                self.swarm.form_line()
+              except Exception as e:
+                logger.warning(f"Swarm formation call failed (line): {e}")
+
+            if event.key == pygame.K_2 and self.swarm:
+              try:
+                self.swarm.form_triangle()
+              except Exception as e:
+                logger.warning(f"Swarm formation call failed (triangle): {e}")
+
+            if event.key == pygame.K_3 and self.swarm:
+              try:
+                self.swarm.form_square()
+              except Exception as e:
+                logger.warning(f"Swarm formation call failed (square): {e}")
+
             # Vision overlay hotkeys
             if event.key == pygame.K_v:
               try:

--- a/src/swarm_command.py
+++ b/src/swarm_command.py
@@ -12,12 +12,12 @@ from cflib.crazyflie.log import LogConfig
 from cflib.crazyflie.syncLogger import SyncLogger
 from cflib.positioning.motion_commander import MotionCommander
 
-from utils import logger, context
+from utils import logger as _log, context
 
 directory = context.get_context(os.path.abspath(__file__))
 logger_file_name = Path(directory).stem
 logger_name = Path(__file__).stem
-logger = logger.setup_logger(
+logger = _log.setup_logger(
   logger_name=logger_name, 
   log_file=f"{directory}/logs/{logger_file_name}.log", 
   log_level=os.getenv("LOG_LEVEL")
@@ -220,3 +220,18 @@ class SwarmCommand:
 
     if not moved:
       self._stop_all()
+
+  def form_line(self):
+    """Arrange drones in a straight line formation."""
+    logger.info("Swarm formation: line (stub)")
+    return None
+
+  def form_triangle(self):
+    """Arrange drones in a triangle formation."""
+    logger.info("Swarm formation: triangle (stub)")
+    return None
+
+  def form_square(self):
+    """Arrange drones in a square formation."""
+    logger.info("Swarm formation: square (stub)")
+    return None


### PR DESCRIPTION
This PR closes #72. Adds stubbed formation preset functions for the swarm (line, triangle, square) and wire them to PyGame keys so we can trigger them without implementing movement yet.